### PR TITLE
Don't compare SHA-2/SHA-1 fingerprints

### DIFF
--- a/agent/azure.c
+++ b/agent/azure.c
@@ -528,7 +528,7 @@ azure_getpubkeys(struct system_config *sc)
 
 			/* Convert certificate into public key */
 			if (shellout(inbuf, &in,
-			    "openssl", "x509", "-fingerprint", "-pubkey",
+			    "openssl", "x509", "-fingerprint", "-sha1", "-pubkey",
 			    "-noout", NULL) != 0) {
 				log_debug("%s: could not get public key",
 				    __func__);


### PR DESCRIPTION
The SSH key fingerprints in the Azure `ovf-env.xml` file are SHA-1 digests but `openssl x509 -fingerprint` uses SHA-2 by default, so `azure_getpubkeys` doesn't pass the correct value to `agent_setpubkey`. This patch explicitly specifies SHA-1 to match the fingerprint provided by Azure.

Closes #9.
